### PR TITLE
fix: restrict system.reactive to 3.1.1 as min but never 4.x series 

### DIFF
--- a/src/Punchclock.Tests/project.json
+++ b/src/Punchclock.Tests/project.json
@@ -2,7 +2,7 @@
   "version": "0.0.0-*",
   "dependencies": {
     "Punchclock": "*",
-    "Splat": "1.5.1",
+    "Splat": "2.0.0",
 
     "xunit": "2.2.0-beta2-build3300"
   },

--- a/src/Punchclock.nuspec
+++ b/src/Punchclock.nuspec
@@ -6,7 +6,7 @@
         <description>Make sure your asynchronous operations show up to work on time</description>
 
         <dependencies>
-            <dependency id="System.Reactive" version="3.0.0" />
+            <dependency id="System.Reactive" version="[3.1.1,4)" />
         </dependencies>
     </metadata>
 

--- a/src/Punchclock/project.json
+++ b/src/Punchclock/project.json
@@ -13,7 +13,7 @@
     "requireLicenseAcceptance": false
   },
   "dependencies": {
-    "System.Reactive": "3.0.0"
+    "System.Reactive": "[3.1.1,4)"
   },
 
   "frameworks": {


### PR DESCRIPTION
Refer to https://github.com/reactiveui/ReactiveUI/pull/1451 for backstory. 

**What is the new behavior (if this is a feature change)?**

Fixes https://github.com/reactiveui/ReactiveUI/pull/1413 by bypassing NuGet issue @ https://github.com/NuGet/Home/issues/5751

**Other information**:

System.Reactive v4.x and NuGet.exe needs more time to mature. We can remove these restrictions as a point release at a later point in time. Dynamic data is currently using `3.1.1` as min but is not clamped @RolandPheasant I strongly recommend that you do the same changes. Similar changes will be applied to Akavache, Refit, Punchclock, etc.
