### PR TITLE
Update to Reactive 4 and netstandard 2

### DIFF
--- a/src/Punchclock.Tests/Punchclock.Tests.csproj
+++ b/src/Punchclock.Tests/Punchclock.Tests.csproj
@@ -44,19 +44,25 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
-
-    <PackageReference Include="reactiveui">
-      <Version>8.0.0-alpha0069</Version>
+    <PackageReference Include="DynamicData">
+      <Version>6.4.0.2419</Version>
+    </PackageReference>
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
+    <PackageReference Include="System.Reactive.Compatibility">
+      <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.2.0</Version>
+      <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.console">
-      <Version>2.2.0</Version>
+      <Version>2.4.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.2.0</Version>
+      <Version>2.4.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Punchclock/Punchclock.csproj
+++ b/src/Punchclock/Punchclock.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature - addresses #21 

**What is the current behavior? (You can also link to an open issue here)**
Dependencies are limited to Reactive 3 to 4


**What is the new behavior (if this is a feature change)?**
Depends on Reactive 4.0


**Does this PR introduce a breaking change?**
Yes, minimum netstandard went from 1.4 to 2.0


**Please check if the PR fulfills these requirements**
- [X] The commit follows our guidelines: https://github.com/reactiveui/reactiveui#contribute

**Other information**:
The test project is also updated to use DynamicData instead of the ReactiveList as per guidance on ReactiveUI docs. All tests pass.
